### PR TITLE
Run JUnit tests in github actions but ignore failure

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,4 +33,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=TeamSpheal_P3-BackEnd -DskipTests=true
+        run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=TeamSpheal_P3-BackEnd -Dmaven.test.failure.ignore=true


### PR DESCRIPTION
Previously the maven build process was stopping on test failure. Since
sonar cloud analysis occurs after testing, this meant that test
failures prevented analysis. This commit changes the build command to
run the tests but not stop on failures. This allows us to have
continuous coverage status.