### PR TITLE
Alter sql file and add secrets for testing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,4 +33,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          REVASPHERE_FRONTEND_URL: "http://localhost:4200"
+          SPRING_PROFILES_ACTIVE: dev
+          REV_EMAIL: ${{ secrets.REV_EMAIL }}
+          REV_PASS: ${{ secrets.REV_PASS }}
+          JWT_SECRET: ${{ secrets.JWT_SECRET }}
         run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=TeamSpheal_P3-BackEnd -Dmaven.test.failure.ignore=true

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -18,7 +18,7 @@ INSERT INTO users (id, email, password, first_name, last_name, profile_img, user
     'ctang'
 );
 
-INSERT INTO posts (id, text, image_url, author_id) VALUES (
+INSERT INTO posts (id, text, image_url, author_id, created_date) VALUES (
     default,
     'The classic',
     'https://i.imgur.com/fhgzVEt.jpeg',
@@ -31,5 +31,3 @@ INSERT INTO posts (id, text, image_url, author_id) VALUES (
     '',
     1, now()
 );
-
-ALTER TABLE users ALTER COLUMN id RESTART WITH (select max(id)+1 from users);


### PR DESCRIPTION
Previously there were 2 issues causing most of the tests to fail with the H2 database on the build server:
1) there was a missing field in the sql file for the insert into the posts table
2) some necessary environment variables were not set on the build server.
This pull request addresses both issues allowing accurate coverage information for each pull request.